### PR TITLE
Mention always included shaders list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ AtmosphericFog for Urp pipeline using Shader Graph
 https://youtu.be/_0VDW6RKSkQ
 
 ## How use:
-Enable Depth Texture in your settings
 
-Add AtmosphericFogRenderFeature in your urp Asset_Renderer and fun with the parameters
+1. Enable Depth Texture in your render pipeline asset settings
+2. Add the "AtmosphericFog" shadergraph into the `Project Settings > Graphics > Always Included Shaders` list
+3. Add AtmosphericFogRenderFeature in your urp Asset_Renderer and have fun with the parameters
 
 ## References:
 


### PR DESCRIPTION
This is exactly what I needed, thank you so much. 🙂

When building on mobile platforms, I had to add the shadergraph into the always include shaders list, otherwise the effect wouldn't work. If it was in the readme like this it would've saved me some time.

It might also apply to PC builds, but I haven't checked that yet. We can change the wording to reflect if it only happens on mobile. Up to you.